### PR TITLE
Add Jekyll SEO support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Or install it yourself as:
 
 ## Usage
 
-This Jekyll theme supports [MailChimp](https://mailchimp.com).
-
 ### Enabling MailChimp
+
+This Jekyll theme supports [MailChimp](https://mailchimp.com).
 
 In order to use this, you must provide your User ID and List ID from MailChimp inside `_config.yml`:
 
@@ -46,6 +46,12 @@ google_analytics: UA-NNNNNNNN-N
 ```
 
 Google Analytics will only appear in production, i.e., `JEKYLL_ENV=production`.
+
+### Jekyll SEO
+
+This theme supports [Jekyll SEO](https://jekyll.github.io/jekyll-seo-tag).
+
+For instructions on how to use this plugin, go to their [Usage Guide](https://jekyll.github.io/jekyll-seo-tag/usage/).
 
 ## Contributing
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+plugins:
+  - jekyll-seo-tag

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,8 +2,8 @@
   {%- if jekyll.environment == 'production' and site.google_analytics -%}
     {%- include google-analytics.html -%}
   {%- endif -%}
-  <title>{{ site.title }}</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
+  {% seo %}
 </head>

--- a/_includes/signup-form.html
+++ b/_includes/signup-form.html
@@ -1,3 +1,4 @@
+<p>Sign up to our newsletter so you can be the first to know when we launch.</p>
 <form id="signup-form" method="post" action="https://xyz.us19.list-manage.com/subscribe/post?u={{ site.mailchimp_userid }}&amp;id={{ site.mailchimp_listid }}" novalidate>
   <input type="email" name="EMAIL" id="mce-EMAIL" placeholder="Email Address" required />
   <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_217e046736397576c90f9357c_4f1044d02e" tabindex="-1" value=""></div>

--- a/jekyll-theme-eventually.gemspec
+++ b/jekyll-theme-eventually.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(assets|_layouts|_includes|_sass|LICENSE|README)!i) }
 
   spec.add_runtime_dependency "jekyll", "~> 3.8"
+  spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.5"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
This PR adds [Jekyll SEO](https://jekyll.github.io/jekyll-seo-tag/) to help in setting up SEO tags.